### PR TITLE
replace django unit test command with make testunit

### DIFF
--- a/vars/DjangoPipeline.groovy
+++ b/vars/DjangoPipeline.groovy
@@ -237,7 +237,7 @@ services:
         steps {
           parallel(
             unit: {
-              sh "make testunit"
+              sh 'make testunit'
             },
             integration: {
               sh 'make testintegration'

--- a/vars/DjangoPipeline.groovy
+++ b/vars/DjangoPipeline.groovy
@@ -237,7 +237,7 @@ services:
         steps {
           parallel(
             unit: {
-              sh "docker run --rm ${IMAGE} python manage.py test --settings=settings.unittesting"
+              sh "make testunit"
             },
             integration: {
               sh 'make testintegration'


### PR DESCRIPTION
I ran into this error when updating tesseract to be a non-django app.  `testunit` now works like `testintegration`