### PR TITLE
Extend the pssh timeout

### DIFF
--- a/vars/pssh.groovy
+++ b/vars/pssh.groovy
@@ -6,7 +6,7 @@ void call(Set<String> hosts, String command) {
       -H "${hosts.sort().join(' ')}" \
       -O StrictHostKeyChecking=no \
       -O UserKnownHostsFile=/dev/null \
-      -t 120 \
+      -t 300 \
       --inline \
       "${command}"
   """


### PR DESCRIPTION
Related to the following error during mysidewalk pre-deploy:
```shell
pssh -H 'p-app-01 p-app-02 p-app-03 p-app-04 p-app-05 p-app-06 p-app-07 p-app-08 p-app-09 p-app-10 p-worker-01 panalytics' -O StrictHostKeyChecking=no -O UserKnownHostsFile=/dev/null -t 120 --inline 'sudo docker pull gcr.io/mindmixer-sidewalk/mysidewalk:latest-prerelease'
...
[12] 22:34:10 [FAILURE] panalytics Timed out, Killed by signal 9
```
Part of the problem is that the pre-deploy occasionally re-downloads the entire image rather than only downloading the affected image layers, and I haven't been able to figure out why. The current image is around 1.3GB, and 2 minutes isn't quite enough time for some instances (usually g1-smalls) to download and extract the entire image. 