### PR TITLE
[PFP-4147] command substitution instead of calling variable pwd

### DIFF
--- a/vars/addNpmTokens.groovy
+++ b/vars/addNpmTokens.groovy
@@ -16,6 +16,6 @@ void call(String service) {
       done
     fi
 
-    rm ${service}.env
+    rm -f ${service}.env
   """
 }

--- a/vars/addNpmTokens.groovy
+++ b/vars/addNpmTokens.groovy
@@ -7,7 +7,7 @@ void call(String environment, String service) {
     set -o pipefail
 
     docker run --rm \
-      -v $(pwd):/output \
+      -v \$(pwd):/output \
       -e ENVIRONMENT=${environment} \
       -e SERVICE=${service} \
       -e CONFD_NODES='["http://config-1:2379", "http://config-2:2379", "http://config-3:2379"]' \

--- a/vars/addNpmTokens.groovy
+++ b/vars/addNpmTokens.groovy
@@ -1,19 +1,12 @@
 #!/usr/bin/env groovy
 
-void call(String environment, String service) {
+void call(String service) {
   sh """
     set -o errexit
     set -o nounset
     set -o pipefail
 
-    docker run --rm \
-      -v \$(pwd):/output \
-      -e ENVIRONMENT=${environment} \
-      -e SERVICE=${service} \
-      -e CONFD_NODES='["http://config-1:2379", "http://config-2:2379", "http://config-3:2379"]' \
-      gcr.io/mindmixer-sidewalk/confd:envfile
-
-    npm_tokens=\$(grep -iP '^npm\.' ${service}.env)
+    npm_tokens=\$(grep -iP '^npm\\.' ${service}.env)
 
     if [[ -n \${npm_tokens} ]]; then
       for token in \${npm_tokens[@]}; do

--- a/vars/addNpmTokens.groovy
+++ b/vars/addNpmTokens.groovy
@@ -7,7 +7,7 @@ void call(String environment, String service) {
     set -o pipefail
 
     docker run --rm \
-      -v ${pwd}:/output \
+      -v $(pwd):/output \
       -e ENVIRONMENT=${environment} \
       -e SERVICE=${service} \
       -e CONFD_NODES='["http://config-1:2379", "http://config-2:2379", "http://config-3:2379"]' \

--- a/vars/getNpmTokens.groovy
+++ b/vars/getNpmTokens.groovy
@@ -1,0 +1,16 @@
+#!/usr/bin/env groovy
+
+void call(String service, String environment) {
+  sh """
+    set -o errexit
+    set -o nounset
+    set -o pipefail
+
+    docker run --rm \
+      -v \$(pwd):/output \
+      -e ENVIRONMENT=${environment} \
+      -e SERVICE=${service} \
+      -e CONFD_NODES='["http://config-1:2379", "http://config-2:2379", "http://config-3:2379"]' \
+      gcr.io/mindmixer-sidewalk/confd:envfile
+  """
+}


### PR DESCRIPTION
- missed this in previous PR
- also broke out `addNpmTokens` into two functions as getting the tokens have to be ran in different stage