### PR TITLE
[PFP-4187] pssh rewrite to use bash background processes and ssh

### DIFF
--- a/vars/pssh.groovy
+++ b/vars/pssh.groovy
@@ -2,12 +2,27 @@
 
 void call(Set<String> hosts, String command) {
   sh """
-    pssh \
-      -H "${hosts.sort().join(' ')}" \
-      -O StrictHostKeyChecking=no \
-      -O UserKnownHostsFile=/dev/null \
-      -t 300 \
-      --inline \
-      "${command}"
+    hosts="${hosts.sort().join(' ')}"
+    tmpdir=/tmp/pssh.\$\$
+    mkdir -p \$tmpdir
+
+    for host in \${hosts[@]}; do
+      timeout 300 ssh \
+        -o StrictHostKeyChecking=no \
+        -o UserKnownHostsFile=/dev/null \
+        -o ConnectTimeout=10 \
+        -o BatchMode=yes \
+        \${host} \
+        "${command}" > \${tmpdir}/\${host} 2>&1 &
+    done
+    
+    wait
+    
+    for host in \${hosts[@]}; do
+      printf "\n\n#################\nOutput: \${host}\n#################\n"
+      cat \${tmpdir}/\${host}
+    done
+    
+    rm -rf \${tmpdir}
   """
 }


### PR DESCRIPTION
- loops through hosts and creates a background ssh process per host
- stdout and stderr gets written to a file per host to keep all output from mixing together
- `timeout` command ensures the background process terminates after 300 seconds like `pssh` did for us
- `wait` has the script pause until all background processes have exited