### PR TITLE
DjangoPipeline: postgres version bump from 9.5 -> 14

### DIFF
--- a/vars/DjangoPipeline.groovy
+++ b/vars/DjangoPipeline.groovy
@@ -176,7 +176,7 @@ services:
     image: ${IMAGE_BASE}/etcd2env
   postgres:
     hostname: postgres
-    image: ${IMAGE_BASE}/postgres:9.5
+    image: ${IMAGE_BASE}/postgres:14
     networks:
       default:
         aliases:


### PR DESCRIPTION
- was causing postgres to not start as `gcr.io/mindmixer-sidewalk/postgres-data:development` is data from postgres 14