### PR TITLE
[PFP-4773] monorepo function remove parallelism

### DIFF
--- a/vars/monorepo.groovy
+++ b/vars/monorepo.groovy
@@ -97,14 +97,8 @@ List<String> findMultibranchPipelinesToRun(List<String> jenkinsfilePaths) {
  * @param multibranchPipelinesToRun The list of Multibranch Pipelines for which a Pipeline is run.
  */
 def runPipelines(String rootFolderPath, List<String> multibranchPipelinesToRun) {
-    println "Running pipelines: $multibranchPipelinesToRun"
-    println "multibranchPipelinesToRun Class: ${multibranchPipelinesToRun.getClass()}"
-    parallel(multibranchPipelinesToRun.inject([:]) { stages, multibranchPipelineToRun ->
-    /*multibranchPipelinesToRun.each { multibranchPipelineToRun ->*/
-        println "multibranchPipelineToRun: $multibranchPipelineToRun"
-        println "stages: ${stages}"
-        println "stages Class: ${stages.getClass()}"
-        stages + [("Build $multibranchPipelineToRun"): {
+    multibranchPipelinesToRun.each { multibranchPipelineToRun ->
+        [:] + [("Build $multibranchPipelineToRun"): {
             def pipelineName = "$rootFolderPath/$multibranchPipelineToRun/${URLEncoder.encode(env.CHANGE_BRANCH ?: env.GIT_BRANCH, 'UTF-8')}"
             // For new branches, Jenkins will receive an event from the version control system to provision the
             // corresponding Pipeline under the Multibranch Pipeline item. We have to wait for Jenkins to process the
@@ -119,7 +113,7 @@ def runPipelines(String rootFolderPath, List<String> multibranchPipelinesToRun) 
             // Trigger downstream builds.
             build(job: pipelineName, propagate: true, wait: true)
         }]
-    })
+    }
 }
 
 /**

--- a/vars/monorepo.groovy
+++ b/vars/monorepo.groovy
@@ -97,7 +97,7 @@ List<String> findMultibranchPipelinesToRun(List<String> jenkinsfilePaths) {
  * @param multibranchPipelinesToRun The list of Multibranch Pipelines for which a Pipeline is run.
  */
 def runPipelines(String rootFolderPath, List<String> multibranchPipelinesToRun) {
-    multibranchPipelinesToRun.inject([:]).each { stages, multibranchPipelineToRun ->
+    multibranchPipelinesToRun.each { multibranchPipelineToRun ->
         stages + [("Build $multibranchPipelineToRun"): {
             def pipelineName = "$rootFolderPath/$multibranchPipelineToRun/${URLEncoder.encode(env.CHANGE_BRANCH ?: env.GIT_BRANCH, 'UTF-8')}"
             // For new branches, Jenkins will receive an event from the version control system to provision the

--- a/vars/monorepo.groovy
+++ b/vars/monorepo.groovy
@@ -113,7 +113,7 @@ def runPipelines(String rootFolderPath, List<String> multibranchPipelinesToRun) 
             // Trigger downstream builds.
             build(job: pipelineName, propagate: true, wait: true)
         }]
-    })
+    }
 }
 
 /**

--- a/vars/monorepo.groovy
+++ b/vars/monorepo.groovy
@@ -119,7 +119,7 @@ def runPipelines(String rootFolderPath, List<String> multibranchPipelinesToRun) 
             // Trigger downstream builds.
             build(job: pipelineName, propagate: true, wait: true)
         }]
-    }
+    })
 }
 
 /**

--- a/vars/monorepo.groovy
+++ b/vars/monorepo.groovy
@@ -97,7 +97,7 @@ List<String> findMultibranchPipelinesToRun(List<String> jenkinsfilePaths) {
  * @param multibranchPipelinesToRun The list of Multibranch Pipelines for which a Pipeline is run.
  */
 def runPipelines(String rootFolderPath, List<String> multibranchPipelinesToRun) {
-    parallel(multibranchPipelinesToRun.inject([:]) { stages, multibranchPipelineToRun ->
+    multibranchPipelinesToRun.each { stages, multibranchPipelineToRun ->
         stages + [("Build $multibranchPipelineToRun"): {
             def pipelineName = "$rootFolderPath/$multibranchPipelineToRun/${URLEncoder.encode(env.CHANGE_BRANCH ?: env.GIT_BRANCH, 'UTF-8')}"
             // For new branches, Jenkins will receive an event from the version control system to provision the

--- a/vars/monorepo.groovy
+++ b/vars/monorepo.groovy
@@ -97,7 +97,13 @@ List<String> findMultibranchPipelinesToRun(List<String> jenkinsfilePaths) {
  * @param multibranchPipelinesToRun The list of Multibranch Pipelines for which a Pipeline is run.
  */
 def runPipelines(String rootFolderPath, List<String> multibranchPipelinesToRun) {
-    multibranchPipelinesToRun.each { multibranchPipelineToRun ->
+    println "Running pipelines: $multibranchPipelinesToRun"
+    println "multibranchPipelinesToRun Class: ${multibranchPipelinesToRun.getClass()}"
+    parallel(multibranchPipelinesToRun.inject([:]) { stages, multibranchPipelineToRun ->
+    /*multibranchPipelinesToRun.each { multibranchPipelineToRun ->*/
+        println "multibranchPipelineToRun: $multibranchPipelineToRun"
+        println "stages: ${stages}"
+        println "stages Class: ${stages.getClass()}"
         stages + [("Build $multibranchPipelineToRun"): {
             def pipelineName = "$rootFolderPath/$multibranchPipelineToRun/${URLEncoder.encode(env.CHANGE_BRANCH ?: env.GIT_BRANCH, 'UTF-8')}"
             // For new branches, Jenkins will receive an event from the version control system to provision the

--- a/vars/monorepo.groovy
+++ b/vars/monorepo.groovy
@@ -98,23 +98,19 @@ List<String> findMultibranchPipelinesToRun(List<String> jenkinsfilePaths) {
  */
 def runPipelines(String rootFolderPath, List<String> multibranchPipelinesToRun) {
     multibranchPipelinesToRun.each { multibranchPipelineToRun ->
-        println "Running $multibranchPipelineToRun"
-        [:] + [("Build $multibranchPipelineToRun"): {
-            def pipelineName = "$rootFolderPath/$multibranchPipelineToRun/${URLEncoder.encode(env.CHANGE_BRANCH ?: env.GIT_BRANCH, 'UTF-8')}"
-            // For new branches, Jenkins will receive an event from the version control system to provision the
-            // corresponding Pipeline under the Multibranch Pipeline item. We have to wait for Jenkins to process the
-            // event so a build can be triggered.
-            timeout(time: 5, unit: 'MINUTES') {
-                waitUntil(initialRecurrencePeriod: 1e3) {
-                    def pipeline = Jenkins.instance.getItemByFullName(pipelineName)
-                    pipeline && !pipeline.isDisabled()
-                }
+        def pipelineName = "$rootFolderPath/$multibranchPipelineToRun/${URLEncoder.encode(env.CHANGE_BRANCH ?: env.GIT_BRANCH, 'UTF-8')}"
+        // For new branches, Jenkins will receive an event from the version control system to provision the
+        // corresponding Pipeline under the Multibranch Pipeline item. We have to wait for Jenkins to process the
+        // event so a build can be triggered.
+        timeout(time: 5, unit: 'MINUTES') {
+            waitUntil(initialRecurrencePeriod: 1e3) {
+                def pipeline = Jenkins.instance.getItemByFullName(pipelineName)
+                pipeline && !pipeline.isDisabled()
             }
+        }
 
-            // Trigger downstream builds.
-            println "Triggering $pipelineName"
-            build(job: pipelineName, propagate: true, wait: true)
-        }]
+        // Trigger downstream builds.
+        build(job: pipelineName, propagate: true, wait: true)
     }
 }
 

--- a/vars/monorepo.groovy
+++ b/vars/monorepo.groovy
@@ -97,7 +97,7 @@ List<String> findMultibranchPipelinesToRun(List<String> jenkinsfilePaths) {
  * @param multibranchPipelinesToRun The list of Multibranch Pipelines for which a Pipeline is run.
  */
 def runPipelines(String rootFolderPath, List<String> multibranchPipelinesToRun) {
-    multibranchPipelinesToRun.each { stages, multibranchPipelineToRun ->
+    multibranchPipelinesToRun.inject([:]).each { stages, multibranchPipelineToRun ->
         stages + [("Build $multibranchPipelineToRun"): {
             def pipelineName = "$rootFolderPath/$multibranchPipelineToRun/${URLEncoder.encode(env.CHANGE_BRANCH ?: env.GIT_BRANCH, 'UTF-8')}"
             // For new branches, Jenkins will receive an event from the version control system to provision the

--- a/vars/monorepo.groovy
+++ b/vars/monorepo.groovy
@@ -98,6 +98,7 @@ List<String> findMultibranchPipelinesToRun(List<String> jenkinsfilePaths) {
  */
 def runPipelines(String rootFolderPath, List<String> multibranchPipelinesToRun) {
     multibranchPipelinesToRun.each { multibranchPipelineToRun ->
+        println "Running $multibranchPipelineToRun"
         [:] + [("Build $multibranchPipelineToRun"): {
             def pipelineName = "$rootFolderPath/$multibranchPipelineToRun/${URLEncoder.encode(env.CHANGE_BRANCH ?: env.GIT_BRANCH, 'UTF-8')}"
             // For new branches, Jenkins will receive an event from the version control system to provision the
@@ -111,6 +112,7 @@ def runPipelines(String rootFolderPath, List<String> multibranchPipelinesToRun) 
             }
 
             // Trigger downstream builds.
+            println "Triggering $pipelineName"
             build(job: pipelineName, propagate: true, wait: true)
         }]
     }


### PR DESCRIPTION
- each package that was modified in a branch or PR will get kicked off _sequentially_ (if it has a `Jenkinsfile` in it)
- this removes issues with 8+ packages having changes in a PR and kicking off each build in parallel
- was not able to keep in the jenkins `stage` but the result is still the same
- tested this [here](https://build.mysidewalk.com/job/tony-test-repo/view/change-requests/job/PR-5/3/console)