### PR TITLE
[PFP-5196] remove PORT env variable regardless of value

### DIFF
--- a/vars/dotenv2yaml.groovy
+++ b/vars/dotenv2yaml.groovy
@@ -7,7 +7,7 @@ void call(String envfile, String outfile) {
     set -o pipefail
 
     # temporarily remove PORT from envfile for Cloud Run
-    sed -i 's/^PORT=80//g' ${envfile}
+    sed -i '/^PORT=/d' ${envfile}
     cat ${envfile} | docker run --rm -i gcr.io/mindmixer-sidewalk/dotenv-to-yaml > ${outfile}
   """
 }


### PR DESCRIPTION
- delete instead of substitute with nothing
- works regardless of the value `PORT` is set to