### PR TITLE
[PFP-4947] Update monorepo baseline revision

### DIFF
--- a/vars/monorepo.groovy
+++ b/vars/monorepo.groovy
@@ -40,7 +40,10 @@ String getBaselineRevision() {
     // Depending on your seed pipeline configuration and preferences, you can set the baseline revision to a target
     // branch, e.g. the repository's default branch or even `env.CHANGE_TARGET` if Jenkins is configured to discover
     // pull requests.
-    [ "origin/$env.CHANGE_TARGET", env.GIT_PREVIOUS_SUCCESSFUL_COMMIT, env.GIT_PREVIOUS_COMMIT]
+    [ "{if (env.CHANGE_TARGET) { "origin/$env.CHANGE_TARGET" }}",
+      env.GIT_PREVIOUS_SUCCESSFUL_COMMIT,
+      env.GIT_PREVIOUS_COMMIT
+    ]
     // Look for the first existing existing revision. Commits can be removed (e.g. with a `git push --force`), so a
     // previous build revision may not exist anymore.
             .find { revision ->

--- a/vars/monorepo.groovy
+++ b/vars/monorepo.groovy
@@ -40,7 +40,7 @@ String getBaselineRevision() {
     // Depending on your seed pipeline configuration and preferences, you can set the baseline revision to a target
     // branch, e.g. the repository's default branch or even `env.CHANGE_TARGET` if Jenkins is configured to discover
     // pull requests.
-    [ "${if (env.CHANGE_TARGET) { "origin/$env.CHANGE_TARGET" }}",
+    [ if (env.CHANGE_TARGET) { "origin/$env.CHANGE_TARGET" },
       env.GIT_PREVIOUS_SUCCESSFUL_COMMIT,
       env.GIT_PREVIOUS_COMMIT
     ]

--- a/vars/monorepo.groovy
+++ b/vars/monorepo.groovy
@@ -46,7 +46,7 @@ String getBaselineRevision() {
     // Look for the first existing existing revision. Commits can be removed (e.g. with a `git push --force`), so a
     // previous build revision may not exist anymore.
             .find { revision ->
-                revision != null && sh(script: "git rev-parse --quiet --verify $revision", returnStdout: true) == 0
+                revision != "" && sh(script: "git rev-parse --quiet --verify $revision", returnStdout: true) == 0
             } ?: 'HEAD^'
 }
 

--- a/vars/monorepo.groovy
+++ b/vars/monorepo.groovy
@@ -40,7 +40,7 @@ String getBaselineRevision() {
     // Depending on your seed pipeline configuration and preferences, you can set the baseline revision to a target
     // branch, e.g. the repository's default branch or even `env.CHANGE_TARGET` if Jenkins is configured to discover
     // pull requests.
-    [env.GIT_PREVIOUS_SUCCESSFUL_COMMIT, env.GIT_PREVIOUS_COMMIT]
+    ["main", "master"]
     // Look for the first existing existing revision. Commits can be removed (e.g. with a `git push --force`), so a
     // previous build revision may not exist anymore.
             .find { revision ->

--- a/vars/monorepo.groovy
+++ b/vars/monorepo.groovy
@@ -40,7 +40,7 @@ String getBaselineRevision() {
     // Depending on your seed pipeline configuration and preferences, you can set the baseline revision to a target
     // branch, e.g. the repository's default branch or even `env.CHANGE_TARGET` if Jenkins is configured to discover
     // pull requests.
-    [ "{if (env.CHANGE_TARGET) { "origin/$env.CHANGE_TARGET" }}",
+    [ "${if (env.CHANGE_TARGET) { "origin/$env.CHANGE_TARGET" }}",
       env.GIT_PREVIOUS_SUCCESSFUL_COMMIT,
       env.GIT_PREVIOUS_COMMIT
     ]

--- a/vars/monorepo.groovy
+++ b/vars/monorepo.groovy
@@ -46,7 +46,7 @@ String getBaselineRevision() {
     // Look for the first existing existing revision. Commits can be removed (e.g. with a `git push --force`), so a
     // previous build revision may not exist anymore.
             .find { revision ->
-                revision != "" && sh(script: "git rev-parse --quiet --verify $revision", returnStdout: true) == 0
+                revision != "" && sh(script: "git rev-parse --quiet --verify $revision", returnStatus: true) == 0
             } ?: 'HEAD^'
 }
 

--- a/vars/monorepo.groovy
+++ b/vars/monorepo.groovy
@@ -40,7 +40,9 @@ String getBaselineRevision() {
     // Depending on your seed pipeline configuration and preferences, you can set the baseline revision to a target
     // branch, e.g. the repository's default branch or even `env.CHANGE_TARGET` if Jenkins is configured to discover
     // pull requests.
-    [ sh(script: "git symbolic-ref refs/remotes/origin/HEAD", returnStdout: true) ]
+    [ sh(script: "git rev-parse --verify -q origin/master || true", returnStdout: true).trim(),
+      sh(script: "git rev-parse --verify -q origin/main || true", returnStdout: true).trim()
+    ]
     // Look for the first existing existing revision. Commits can be removed (e.g. with a `git push --force`), so a
     // previous build revision may not exist anymore.
             .find { revision ->

--- a/vars/monorepo.groovy
+++ b/vars/monorepo.groovy
@@ -45,7 +45,7 @@ String getBaselineRevision() {
     // previous build revision may not exist anymore.
             .find { revision ->
                 revision != null && sh(script: "git rev-parse --quiet --verify $revision", returnStatus: true) == 0
-            }
+            } ?: 'HEAD^'
 }
 
 /**

--- a/vars/monorepo.groovy
+++ b/vars/monorepo.groovy
@@ -40,14 +40,12 @@ String getBaselineRevision() {
     // Depending on your seed pipeline configuration and preferences, you can set the baseline revision to a target
     // branch, e.g. the repository's default branch or even `env.CHANGE_TARGET` if Jenkins is configured to discover
     // pull requests.
-    [ sh(script: "git rev-parse --verify -q origin/master || true", returnStdout: true).trim(),
-      sh(script: "git rev-parse --verify -q origin/main || true", returnStdout: true).trim()
-    ]
+    [ "origin/$env.CHANGE_TARGET", env.GIT_PREVIOUS_SUCCESSFUL_COMMIT, env.GIT_PREVIOUS_COMMIT]
     // Look for the first existing existing revision. Commits can be removed (e.g. with a `git push --force`), so a
     // previous build revision may not exist anymore.
             .find { revision ->
-                revision != "" && sh(script: "git rev-parse --quiet --verify $revision", returnStatus: true) == 0
-            } ?: 'HEAD^'
+                revision != null && sh(script: "git rev-parse --quiet --verify $revision", returnStatus: true) == 0
+            }
 }
 
 /**

--- a/vars/monorepo.groovy
+++ b/vars/monorepo.groovy
@@ -40,14 +40,14 @@ String getBaselineRevision() {
     // Depending on your seed pipeline configuration and preferences, you can set the baseline revision to a target
     // branch, e.g. the repository's default branch or even `env.CHANGE_TARGET` if Jenkins is configured to discover
     // pull requests.
-    [ if (env.CHANGE_TARGET) { "origin/$env.CHANGE_TARGET" },
+    [ "origin/$env.CHANGE_TARGET",
       env.GIT_PREVIOUS_SUCCESSFUL_COMMIT,
       env.GIT_PREVIOUS_COMMIT
     ]
     // Look for the first existing existing revision. Commits can be removed (e.g. with a `git push --force`), so a
     // previous build revision may not exist anymore.
             .find { revision ->
-                revision != null && sh(script: "git rev-parse --quiet --verify $revision", returnStatus: true) == 0
+                revision != "origin/" && revision != null && sh(script: "git rev-parse --quiet --verify $revision", returnStatus: true) == 0
             } ?: 'HEAD^'
 }
 

--- a/vars/monorepo.groovy
+++ b/vars/monorepo.groovy
@@ -40,7 +40,7 @@ String getBaselineRevision() {
     // Depending on your seed pipeline configuration and preferences, you can set the baseline revision to a target
     // branch, e.g. the repository's default branch or even `env.CHANGE_TARGET` if Jenkins is configured to discover
     // pull requests.
-    ["main", "master"]
+    [ sh(script: "git rev-parse --abbrev-ref origin/HEAD", returnStdout: true) ]
     // Look for the first existing existing revision. Commits can be removed (e.g. with a `git push --force`), so a
     // previous build revision may not exist anymore.
             .find { revision ->

--- a/vars/monorepo.groovy
+++ b/vars/monorepo.groovy
@@ -47,7 +47,7 @@ String getBaselineRevision() {
     // Look for the first existing existing revision. Commits can be removed (e.g. with a `git push --force`), so a
     // previous build revision may not exist anymore.
             .find { revision ->
-                revision != "origin/" && revision != null && sh(script: "git rev-parse --quiet --verify $revision", returnStatus: true) == 0
+                revision != "origin/null" && revision != null && sh(script: "git rev-parse --quiet --verify $revision", returnStatus: true) == 0
             } ?: 'HEAD^'
 }
 

--- a/vars/monorepo.groovy
+++ b/vars/monorepo.groovy
@@ -40,7 +40,7 @@ String getBaselineRevision() {
     // Depending on your seed pipeline configuration and preferences, you can set the baseline revision to a target
     // branch, e.g. the repository's default branch or even `env.CHANGE_TARGET` if Jenkins is configured to discover
     // pull requests.
-    [ sh(script: "git rev-parse --abbrev-ref origin/HEAD", returnStdout: true) ]
+    [ sh(script: "git symbolic-ref refs/remotes/origin/HEAD", returnStdout: true) ]
     // Look for the first existing existing revision. Commits can be removed (e.g. with a `git push --force`), so a
     // previous build revision may not exist anymore.
             .find { revision ->


### PR DESCRIPTION
- currently, the `monorepo()` command looks for changed files from the previous commit
- this PR changes that behavior to check for changed files from the default branch 