### PR TITLE
[PFP-5276] Cloud Run Labels

### DIFF
--- a/vars/cloudRunDeploy.groovy
+++ b/vars/cloudRunDeploy.groovy
@@ -1,6 +1,6 @@
 #!/usr/bin/env groovy
 
-void call(String serviceName, String region, String image, String envfile) {
+void call(String serviceName, String region, String image, String envfile='') {
   sh """
     set -o errexit
     set -o nounset

--- a/vars/cloudRunDeploy.groovy
+++ b/vars/cloudRunDeploy.groovy
@@ -10,13 +10,13 @@ void call(String serviceName, String region, String image, String envfile) {
       gcloud run deploy ${serviceName} \
         --quiet \
         --image=${image} \
-        --update-labels managed-by=jenkins,commit-sha=${env.GIT_COMMIT} \
+        --update-labels=managed-by=jenkins,commit-sha=${env.GIT_COMMIT} \
         --region=${region}
     else
       gcloud run deploy ${serviceName} \
         --quiet \
         --image=${image} \
-        --update-labels managed-by=jenkins,commit-sha=${env.GIT_COMMIT} \
+        --update-labels=managed-by=jenkins,commit-sha=${env.GIT_COMMIT} \
         --region=${region} \
         --env-vars-file=${envfile}
     fi

--- a/vars/cloudRunDeploy.groovy
+++ b/vars/cloudRunDeploy.groovy
@@ -7,9 +7,18 @@ void call(String serviceName, String region, String image, String envfile) {
     set -o pipefail
 
     if [ -z "${envfile}" ]; then
-      gcloud run deploy ${serviceName} --image=${image} --region=${region}
+      gcloud run deploy ${serviceName} \
+        --quiet \
+        --image=${image} \
+        --update-labels managed-by=jenkins,commit-sha=${env.GIT_COMMIT} \
+        --region=${region}
     else
-      gcloud run deploy ${serviceName} --image=${image} --region=${region} --env-vars-file=${envfile}
+      gcloud run deploy ${serviceName} \
+        --quiet \
+        --image=${image} \
+        --update-labels managed-by=jenkins,commit-sha=${env.GIT_COMMIT} \
+        --region=${region} \
+        --env-vars-file=${envfile}
     fi
   """
 }


### PR DESCRIPTION
- add `managed-by` and `commit-sha` labels to cloud run deployments
- `--quiet` parameter
- fix issue with calling function without `envfile`