### PR TITLE
[PFP-6110] leave untagged images in GAR

### DIFF
--- a/vars/imageDeleteUntagged.groovy
+++ b/vars/imageDeleteUntagged.groovy
@@ -4,9 +4,4 @@ void call(String image) {
   echo "Deleting untagged images of ${image}."
   // Filtering is done on image and then dangling on that subset, potentially resulting in not truly dangling images
   sh "docker images '${image}' -qf 'dangling=true' | xargs --no-run-if-empty docker rmi || true"
-  sh """
-    gcloud container images list-tags ${image} --filter='NOT tags:*' --format=json \
-      | jq '.[].digest' \
-      | xargs --no-run-if-empty -I {} gcloud container images delete -q ${image}@{}
-  """
 }


### PR DESCRIPTION
- since switching `build` to use the `container.d` image store, images now will contain multiple "images" referencing each other
- this shared command is failing to delete untagged images since they are referenced by another image
- we already have GAR setup to delete untagged images after a few months and GAR understands the manifests between images
- error from cleanup step in jenkins build [here](https://build.mysidewalk.com/blue/organizations/jenkins/frontend/detail/edge/661/pipeline/)